### PR TITLE
Add namespace to builtin in XML

### DIFF
--- a/libycp/src/YExpression.cc
+++ b/libycp/src/YExpression.cc
@@ -1946,7 +1946,7 @@ YEBuiltin::toStream (std::ostream & str) const
 std::ostream &
 YEBuiltin::toXml( std::ostream & str, int indent ) const
 {
-    str << "<builtin name=\"" << m_decl->name << "\"";
+    str << "<builtin name=\"" << StaticDeclaration::Decl2String(m_decl) << "\"";
 
     if (m_parameterblock != 0)
     {


### PR DESCRIPTION
Before change ycpc generates <builtin name="Dir" ...
After change it generates <builtin name="SCR::Dir"
This allows to better match difference between builtins with
namespace and without it.
