### PR TITLE
agent-any: stub "df" for testing.

### DIFF
--- a/agent-any/testsuite/tests/run_df.in
+++ b/agent-any/testsuite/tests/run_df.in
@@ -1,0 +1,22 @@
+Filesystem     1024-blocks    Used Available Capacity Mounted on
+/dev/vda2         14672896 5391208   7916888      41% /
+devtmpfs            973860       0    973860       0% /dev
+tmpfs               981768     216    981552       1% /dev/shm
+tmpfs               981768   18184    963584       2% /run
+tmpfs               981768       0    981768       0% /sys/fs/cgroup
+/dev/vda2         14672896 5391208   7916888      41% /.snapshots
+/dev/vda2         14672896 5391208   7916888      41% /var/tmp
+/dev/vda2         14672896 5391208   7916888      41% /var/spool
+/dev/vda2         14672896 5391208   7916888      41% /var/opt
+/dev/vda2         14672896 5391208   7916888      41% /var/log
+/dev/vda2         14672896 5391208   7916888      41% /tmp
+/dev/vda2         14672896 5391208   7916888      41% /var/lib/pgsql
+/dev/vda2         14672896 5391208   7916888      41% /var/lib/named
+/dev/vda2         14672896 5391208   7916888      41% /var/lib/mailman
+/dev/vda2         14672896 5391208   7916888      41% /var/crash
+/dev/vda2         14672896 5391208   7916888      41% /usr/local
+/dev/vda2         14672896 5391208   7916888      41% /srv
+/dev/vda2         14672896 5391208   7916888      41% /opt
+/dev/vda2         14672896 5391208   7916888      41% /home
+/dev/vda2         14672896 5391208   7916888      41% /boot/grub2/x86_64-efi
+/dev/vda2         14672896 5391208   7916888      41% /boot/grub2/i386-pc

--- a/agent-any/testsuite/tests/run_df.scr
+++ b/agent-any/testsuite/tests/run_df.scr
@@ -2,7 +2,9 @@
 
 `ag_anyagent(
   `Description (
-      (`Run("/bin/df -P 2>/dev/null")),         // real file name
+// in production, .run.df has
+//      (`Run("/bin/df -P 2>/dev/null")),
+      (`File("tests/run_df.in")),         // real file name
       "\n",                     // Comment
       true,                     // read-only
       (`List (

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 11 11:13:42 UTC 2014 - mvidner@suse.com
+
+- agent-any: stub "df" for testing.
+- 3.1.9
+
+-------------------------------------------------------------------
 Fri Aug  8 07:59:56 UTC 2014 - mvidner@suse.com
 
 - Pass SCR root path to stdio agents (bnc#879365).

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -18,7 +18,7 @@
 
 
 Name:           yast2-core
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
A Jenkins worker in a broken state would say
df: no file systems processed

But we are interested in the parsing, so stub it by its usual output.
