### PR TITLE
Fixed WFM language initialization

### DIFF
--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jan 22 19:10:06 UTC 2015 - lslezak@suse.cz
+
+- skip empty environment variables when activating the locale
+  settings, fixes inconsistent locale setting when started
+  via "kdesu" with unchecked "Remember password" option
+  (boo#914081)
+- 3.1.15
+
+-------------------------------------------------------------------
 Tue Nov 25 09:59:49 UTC 2014 - mvidner@suse.com
 
 - ag_any: respect target root also when the file

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -18,7 +18,7 @@
 
 
 Name:           yast2-core
-Version:        3.1.14
+Version:        3.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/wfm/src/Y2WFMComponent.cc
+++ b/wfm/src/Y2WFMComponent.cc
@@ -230,7 +230,7 @@ Y2WFMComponent::get_env_lang () const
     for (size_t i = 0; i < sizeof (names)/sizeof (names[0]); i++)
     {
 	const char* tmp = getenv (names[i]);
-	if (tmp)
+	if (tmp && tmp[0] != '\0')
 	    return tmp;
     }
 


### PR DESCRIPTION
Skip empty environment variables when activating the locale settings, fixes inconsistent locale setting when started via `kdesu` with unchecked "Remember password" option.

See [boo#914081](https://bugzilla.suse.com/show_bug.cgi?id=914081#c4) for more details.

- 3.1.15