### PR TITLE
Fix gcc5 symbol

### DIFF
--- a/liby2util-r/src/include/y2util/Ustring.h
+++ b/liby2util-r/src/include/y2util/Ustring.h
@@ -49,9 +49,9 @@ class UstringHash
 
   public:
 
-    const std::string & add( const std::string & nstr_r )
+    const std::string * add( const std::string & nstr_r )
     {
-	return *(_UstringHash.insert( nstr_r ).first);
+	return &(*(_UstringHash.insert( nstr_r ).first));
     }
 
     /**
@@ -128,12 +128,7 @@ class Ustring
  {
 
   private:
-
-    /**
-     * !!! It should actualy be const !!!
-     * But that way default copy and assingment can be used.
-     **/
-    std::string _name;
+    const std::string* _name;
 
   public:
 #ifdef D_MEMUSAGE
@@ -147,12 +142,21 @@ class Ustring
       :_name( nameHash_r.add( n ) )
     {}
 
+    Ustring( const Ustring& cpy)
+      :_name(cpy._name)
+    {}
+
+    const Ustring& operator=(const Ustring& orig)
+    {
+      _name = orig._name;
+      return *this;
+    }
   public:
 
     /**
      * Conversion to const std::string &
      **/
-    const std::string & asString() const { return _name; }
+    const std::string & asString() const { return *_name; }
 
     /**
      * Conversion to const std::string &
@@ -175,29 +179,29 @@ class Ustring
     }
 
     int compare( const Ustring & rhs ) const {
-      if ( *this == rhs )
+      if ( this == &rhs )
 	return 0;
-      return( *this < rhs ? -1 : 1 );
+      return _name->compare(rhs.asString());
     }
 
     /**
      * ustr->???(); // short for ((const std::string &)ustr).???();
      **/
-    const std::string * operator->() const { return & asString(); }
+    const std::string * operator->() const { return _name; }
 
     // operator ==
 
     friend bool operator==( const Ustring & lhs, const Ustring & rhs ) {
       // Ustrings share their string representation
-      return ( lhs->c_str() == rhs->c_str() );
+      return ( lhs._name == rhs._name );
     }
 
     friend bool operator==( const Ustring & lhs, const std::string & rhs ) {
-      return ( (const std::string &)lhs == rhs );
+      return ( lhs.asString() == rhs );
     }
 
     friend bool operator==( const std::string & lhs, const Ustring & rhs ) {
-      return ( lhs == (const std::string &)rhs );
+      return ( lhs == rhs.asString() );
     }
 
     // operator !=

--- a/scr/src/ScriptingAgent.cc
+++ b/scr/src/ScriptingAgent.cc
@@ -169,7 +169,7 @@ ScriptingAgent::parseSingleConfigFile (const string &filename)
 	    if (agent != agents.end ())
 	    {
 		// TODO promote more debugs to errors or warnings
-    		y2warning ("Ignoring re-registration of path '%s'", path->toString ().c_str ());
+    		y2debug ("Ignoring re-registration of path '%s'", path->toString ().c_str ());
 		// possible alternative: do not ignore
 		// - ok if the agent was not used yet (not mounted yet)
 		// - umount if mounted??


### PR DESCRIPTION
@mvidner I do not create changelog entry yet as I found my fix quite controversial as it break API and ABI and https://github.com/yast/yast-core/commit/019376a444885db2adb56e4d275051b21d6d9752 is needed as it start failed in one testcase but I cannot reproduce it in chroot env. Just in osc build it reregister agents.
I verify that it fix issue and also fix a logic of Ustring as it is not used as immutable class when you allow operator= which is used in some places.

Change of reference to pointer is needed to allow switching Ustring to different symbol when assigning new value there e.g. in Import class. Another option is to make usage of Ustring immutable to disable operator= and then modify code to not copy anything to ustring and just passing pointers to Ustring are known.