### PR TITLE
Fix Symbol comparison as String in gcc no longer use COW for all strings

### DIFF
--- a/liby2util-r/src/include/y2util/Ustring.h
+++ b/liby2util-r/src/include/y2util/Ustring.h
@@ -189,7 +189,7 @@ class Ustring
 
     friend bool operator==( const Ustring & lhs, const Ustring & rhs ) {
       // Ustrings share their string representation
-      return ( lhs->c_str() == rhs->c_str() );
+      return ( lhs.asString() ==  rhs.asString() );
     }
 
     friend bool operator==( const Ustring & lhs, const std::string & rhs ) {

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 30 10:55:31 UTC 2015 - jreidinger@suse.com
+
+- Fix YCP symbol comparison with GCC 5 (thanks schubi for
+  performance measurement and mvidner for review) (boo#914255)
+- 3.1.17
+
+-------------------------------------------------------------------
 Tue Mar  3 14:49:39 UTC 2015 - mvidner@suse.com
 
 - Fixed compilation (but not tests) with GCC 5 (boo#914255).

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-core
-Version:        3.1.16
+Version:        3.1.17
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
Do not merge yet. Only for performance testing