### PR TITLE
Silence compiler-warnings

### DIFF
--- a/agent-any/src/AnyAgent.cc
+++ b/agent-any/src/AnyAgent.cc
@@ -675,7 +675,7 @@ static FILE* program_stream(const char *s, SCRAgent* agent)
 
               // Do not allow touch outside of chroot especially `cd ~` can
               // cause errors
-              chdir("/");
+              if(chdir("/"));
             }
             // lets ignore if it fails, we even cannot log here
             setenv ("LC_ALL", "C", 1);

--- a/agent-ini/src/IniParser.cc
+++ b/agent-ini/src/IniParser.cc
@@ -770,7 +770,7 @@ int IniParser::parse_helper(IniSection&ini)
 				    if (name_to_close.empty ()) {
 					// there was no name or we did not find the specified one
 					for (it = b; it != e; ++it) {
-					    if ((*it)->getReadBy() == i)
+					    if ((*it)->getReadBy() == (int) i)
 						break;
 					}
 					if (it == e) {

--- a/agent-system/src/ShellCommand.cc
+++ b/agent-system/src/ShellCommand.cc
@@ -162,7 +162,7 @@ shellcommand ( const string &target_root, const string &command, const string &t
 
                 // Do not allow touch outside of chroot especially `cd ~` can
                 // cause errors
-                chdir("/");
+                if(chdir("/"));
             }
 
 	    ret = system (command.c_str ());

--- a/base/tools/startshell/startshell.c
+++ b/base/tools/startshell/startshell.c
@@ -28,8 +28,8 @@ inst_start_shell (char *tty_tv)
     setsid ();
     fd_ii = open (tty_tv, O_RDWR);
     ioctl (fd_ii, TIOCSCTTY, (void *)1);
-    dup (fd_ii);
-    dup (fd_ii);
+    if (dup (fd_ii));
+    if (dup (fd_ii));
 
     execve ("/bin/bash", args_apci, env_pci);
     fprintf (stderr, "Couldn't start shell (errno = %d)\n", errno);

--- a/liby2/src/Y2ProgramComponent.cc
+++ b/liby2/src/Y2ProgramComponent.cc
@@ -302,7 +302,7 @@ void Y2ProgramComponent::launchExternalProgram (char **argv)
 		_exit (5);
 	    }
 
-	    chdir ("/");
+	    if(chdir ("/"));
 	}
 
 	// close all filedescriptors above stderr, bnc#501758
@@ -419,7 +419,7 @@ void Y2ProgramComponent::sendToExternal(const string& value)
     // result (..) from the input pipe, which is very important. Otherwise the
     // result value would be dropped.
 
-    write(to_external[1], "\n", 1);
+    if(write(to_external[1], "\n", 1));
 }
 
 

--- a/liby2/src/Y2SerialComponent.cc
+++ b/liby2/src/Y2SerialComponent.cc
@@ -344,13 +344,13 @@ bool Y2SerialComponent::initializeConnection()
 
 	 // first write one space so the other side gets
 	 // fullfilled its necessities
-	 write(fd_serial, space_buf, 1);
+	 if(write(fd_serial, space_buf, 1));
 
 	 // now wait for a space to be read
 	 // (the other side has the same behaviour)
 	 if (await_readable(TIMEOUT))
 	 {
-	    read(fd_serial, buf, 1);	            // read one byte
+	    if(read(fd_serial, buf, 1));	    // read one byte
 
 	    if (buf[0] == ' ') spaces_read++;       // was a space
 	    else               spaces_read = 0;     // trash read --> reset
@@ -360,7 +360,7 @@ bool Y2SerialComponent::initializeConnection()
       // now that we've got our NUMSPACES spaces write 2 * NUMSPACES spaces to
       // the other side to avoid syncing problems. the remote parser will kindly
       // ignore them.
-      write(fd_serial, space_buf, 2 * NUMSPACES);
+      if(write(fd_serial, space_buf, 2 * NUMSPACES));
 
       // now set our parser to the serial line to start communication
       parser.setInput(fd_serial, device_name.c_str());
@@ -378,7 +378,7 @@ void Y2SerialComponent::sendToSerial(const YCPValue& v)
 {
     string s  = "(" + v->toString() + ")\n";    // store string in string variable ..
     const char *cs = s.c_str();        		// c_str is valid als long as s
-    write(fd_serial, cs, strlen(cs));
+    if(write(fd_serial, cs, strlen(cs)));
 }
 
 YCPValue Y2SerialComponent::receiveFromSerial()

--- a/liby2/src/Y2StdioComponent.cc
+++ b/liby2/src/Y2StdioComponent.cc
@@ -127,7 +127,7 @@ Y2StdioComponent::send (const YCPValue& v) const
 {
     string s = "(" + (v.isNull () ? "(nil)" : v->toString ()) + ")\n";
     y2debug ("send begin %s", s.c_str ());
-    write (to_stderr ? STDERR_FILENO : STDOUT_FILENO, s.c_str (), s.length ());
+    if(write (to_stderr ? STDERR_FILENO : STDOUT_FILENO, s.c_str (), s.length ()));
     y2debug ("send end %s", s.c_str ());
 }
 

--- a/liby2/src/genericfrontend.cc
+++ b/liby2/src/genericfrontend.cc
@@ -856,7 +856,7 @@ print_error (const char* format, ...)
 
     va_list ap;
     va_start (ap, format);
-    vasprintf (&msg, format, ap);
+    if(vasprintf (&msg, format, ap));
     va_end (ap);
 
     fprintf (stderr, "%s\n", msg);

--- a/liby2util-r/src/y2changes.cc
+++ b/liby2util-r/src/y2changes.cc
@@ -104,7 +104,9 @@ static int dup_stderr()
     }
     return 1;
 }
+/* silence '-Wunused-variable' */
 static int variable_not_used = dup_stderr();
+void y2changes_function_not_used() {if (variable_not_used);}
 
 static FILE * open_logfile()
 {

--- a/liby2util-r/src/y2changes.cc
+++ b/liby2util-r/src/y2changes.cc
@@ -140,7 +140,7 @@ string y2_changesfmt_prefix (logcategory_t category)
     strftime (date, sizeof (date), Y2CHANGES_DATE, brokentime);
 
     char * result_c = NULL;
-    asprintf (&result_c, Y2CHANGES_FORMAT, date, log_messages[category], hostname );
+    if(asprintf (&result_c, Y2CHANGES_FORMAT, date, log_messages[category], hostname ));
     string result = result_c;
     free (result_c);
 
@@ -157,7 +157,7 @@ void y2changes_function (logcategory_t category, const char *format, ...)
 
     /* Prepare the log text */
     char *logtext = NULL;
-    vasprintf(&logtext, format, ap); /* GNU extension needs the define above */
+    if(vasprintf(&logtext, format, ap)); /* GNU extension needs the define above */
     string common = logtext;
     common += '\n';
     free (logtext);
@@ -291,7 +291,7 @@ static void shift_log_files(string filename)
     rename( filename.c_str(), old (filename, 1, "").c_str() );
     // fate#300637: compress!
     // may fail, but so what
-    system( ("nice -n 20 gzip " + old (filename, 1, "") + " &").c_str());
+    if(system( ("nice -n 20 gzip " + old (filename, 1, "") + " &").c_str()));
 }
 
 

--- a/liby2util-r/src/y2log.cc
+++ b/liby2util-r/src/y2log.cc
@@ -126,7 +126,9 @@ static int dup_stderr()
     }
     return 1;
 }
+/* silence '-Wunused-variable' */
 static int variable_not_used = dup_stderr();
+void y2log_function_not_used() {if (variable_not_used);}
 
 static FILE * open_logfile()
 {

--- a/liby2util-r/src/y2log.cc
+++ b/liby2util-r/src/y2log.cc
@@ -179,7 +179,7 @@ string y2_logfmt_common(bool simple, const string& component, const char *file,
 {
     /* Prepare the log text */
     char *logtext = NULL;
-    vasprintf(&logtext, format, ap); /* GNU extension needs the define above */
+    if(vasprintf(&logtext, format, ap)); /* GNU extension needs the define above */
 
     /* Prepare the component */
     string comp = component;
@@ -218,8 +218,8 @@ string y2_logfmt_common(bool simple, const string& component, const char *file,
 	eol = true;
 
     char * result_c;
-    asprintf(&result_c, simple? Y2LOG_SIMPLE: Y2LOG_COMMON,
-	     comp.c_str (), file, func.c_str (), line, logtext, eol?"\n":"");
+    if(asprintf(&result_c, simple? Y2LOG_SIMPLE: Y2LOG_COMMON,
+	     comp.c_str (), file, func.c_str (), line, logtext, eol?"\n":""));
     string result = result_c;
     free (result_c);
 
@@ -269,7 +269,7 @@ string y2_logfmt_prefix (loglevel_t level)
 #endif
 
     char * result_c = NULL;
-    asprintf (&result_c, Y2LOG_FORMAT, date, level, hostname, pid);
+    if(asprintf (&result_c, Y2LOG_FORMAT, date, level, hostname, pid));
     string result = result_c;
     free (result_c);
 
@@ -465,7 +465,7 @@ static void shift_log_files(string filename)
     rename( filename.c_str(), old (filename, 1, "").c_str() );
     // fate#300637: compress!
     // may fail, but so what
-    system( ("nice -n 20 gzip " + old (filename, 1, "") + " &").c_str());
+    if(system( ("nice -n 20 gzip " + old (filename, 1, "") + " &").c_str()));
 }
 
 

--- a/libycp/src/pathsearch.cc
+++ b/libycp/src/pathsearch.cc
@@ -192,7 +192,7 @@ Y2PathSearch::findy2exe (string root, string compname, bool server,
     {
 	// Check at least if it is executable (for others) and
 	// if it is a regular file.
-	if (S_ISREG (buf.st_mode) && (buf.st_mode & S_IXOTH == S_IXOTH))
+	if (S_ISREG (buf.st_mode) && ((buf.st_mode & S_IXOTH) == S_IXOTH))
 	{
 	    return pathname;
 	}


### PR DESCRIPTION
Silence the following warnings to reduce cluttering messages during compile:

* -Wunused-result
* -Wparentheses
* -Wsign-compare
* -Wunused-variable