### PR TITLE
fix more compilation warnings

### DIFF
--- a/liby2util-r/src/y2changes.cc
+++ b/liby2util-r/src/y2changes.cc
@@ -102,7 +102,7 @@ static int dup_stderr()
     }
     return 1;
 }
-static int variable_not_used = dup_stderr();
+static int variable_not_used __attribute__ ((unused)) = dup_stderr();
 
 static FILE * open_logfile()
 {

--- a/liby2util-r/src/y2log.cc
+++ b/liby2util-r/src/y2log.cc
@@ -123,7 +123,7 @@ static int dup_stderr()
     }
     return 1;
 }
-static int variable_not_used = dup_stderr();
+static int variable_not_used __attribute__ ((unused)) = dup_stderr();
 
 static FILE * open_logfile()
 {

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May 13 19:56:50 CEST 2015 - besser82@fedoraproject.org
+
+- Fix more compilation warnings.
+
+-------------------------------------------------------------------
 Mon May 11 13:50:04 UTC 2015 - mvidner@suse.com
 
 - Fixed compilation warnings.


### PR DESCRIPTION
silence `warning: 'variable_not_used' defined but not used [-Wunused-variable]`