### PR TITLE
Treat C/C++ warnings as errors

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -53,7 +53,7 @@ AC_PROG_CXX
 # gnu++0x instead of c++0x so that
 # we do not lose gnu extensions like typeof
 # FIXME: rename to Y2CORE_CXXFLAGS and change in devtools:y2autoconf
-Y2CORE_CFLAGS="-std=gnu++0x"
+Y2CORE_CFLAGS="-std=gnu++0x -Werror"
 AC_SUBST(Y2CORE_CFLAGS) dnl included in CXXFLAGS in YAST2-CHECKS-PROGRAM
 
 AC_CHECK_HEADERS(xcrypt.h)

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb  2 12:17:32 UTC 2016 - mvidner@suse.com
+
+- Treat C/C++ warnings as errors.
+- 3.1.20
+
+-------------------------------------------------------------------
 Tue Jan 19 10:08:56 UTC 2016 - jreidinger@suse.com
 
 - ag_ini: when multifile list contain glob, evaluate it in correct

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-core
-Version:        3.1.19
+Version:        3.1.20
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
Since 2d35665 was the last GCC warning fixed we can now afford to treat them as errors and fix newly detected ones as soon as they appear.