### PR TITLE
Use Docker at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "docbook-xsl xsltproc yast2-devtools bison flex libboost-dev pkg-config expect dejagnu libxcrypt-dev doxygen language-pack-en language-pack-cs automake"
-script:
-    - make -f Makefile.cvs
-    - make -j 4
-    - sudo make install
-    # some tests fail in Ubuntu 12.04, disable tests temporarily to avoid false errors :-(
-    # - make check
-    # debugging: this test fails for some reason, looks like a strange locale related problem... :-(
-    # - (cd libycp; export LC_ALL=C; make check)
-    # - diff -u libycp/testsuite/tmp.out.Builtin_VIII libycp/testsuite/tests/builtin/Builtin_VIII.out
-    # - locale
+sudo: required
+language: ruby
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-core-image .
+script:
+  # the "yast-travis" script is included in the base yastdevel/ruby-tw image
+  # see https://github.com/yast/docker-yast-ruby-tw/blob/master/yast-travis
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-core-image yast-travis-cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM yastdevel/cpp-tw
 # the tests require specific locale settings to pass
 ENV LANG=POSIX LC_ALL=
 COPY . /tmp/sources
-
+# Remove the preinstalled yast2-core, it interferes with the built one
+# when running the tests... (huh??)
+RUN zypper --non-interactive rm yast2-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM yastdevel/cpp-tw
+# the tests require specific locale settings to pass
+ENV LANG=POSIX LC_ALL=
+COPY . /tmp/sources
+


### PR DESCRIPTION
- Use the prebuilt Docker image
- Fixed the issue with some failed String tests, they require a specific locale setup
- Thanks to the fact that I could run the Docker image locally the debugging was much easier than in the previous Travis Ubuntu VM! :+1: :+1:
- So now we can run the full testsuite in Travis and even build the RPM package! :tada: See the Travis log!
- Though there was one tricky point: the preinstalled yast2-core interfered with the built one when running some SCR tests, workarounded by removing it at the beginning