### PR TITLE
Fixed newly uncovered C++ warnings

### DIFF
--- a/liby2/src/Y2Namespace.cc
+++ b/liby2/src/Y2Namespace.cc
@@ -41,7 +41,7 @@ Y2Namespace::Y2Namespace ()
 {}
 
 
-Y2Namespace::~Y2Namespace ()
+Y2Namespace::~Y2Namespace () noexcept(false)
 {
 #if DO_DEBUG
     y2debug ("Y2Namespace::~Y2Namespace [%p]", this);

--- a/liby2/src/include/y2/Y2Namespace.h
+++ b/liby2/src/include/y2/Y2Namespace.h
@@ -75,7 +75,7 @@ public:
 
     Y2Namespace ();
 
-    virtual ~Y2Namespace();
+    virtual ~Y2Namespace() noexcept(false);
 
     // end of symbols, finish and clean up m_symbols
     void finish ();

--- a/liby2util-r/src/include/y2util/Rep.h
+++ b/liby2util-r/src/include/y2util/Rep.h
@@ -81,7 +81,7 @@ class Rep {
     /**
      * Destructor. Throws exception if reference count is not zero.
      **/
-    virtual ~Rep() { if ( _counter ) throw( this ); }
+    virtual ~Rep() noexcept(false) { if ( _counter ) throw( this ); }
 
   public:
 

--- a/libycp/src/YExpression.cc
+++ b/libycp/src/YExpression.cc
@@ -1451,7 +1451,7 @@ YEBinary::toXml (std::ostream & str, int /*indent*/ ) const
 constTypePtr
 YEBinary::type () const
 {
-    if (m_decl->flags && DECL_FLEX)
+    if (m_decl->flags & DECL_FLEX)
     {
 	// reconstruct type
 	FunctionTypePtr ft = new FunctionType (Type::Unspec);

--- a/libycp/src/include/ycp/Bytecode.h
+++ b/libycp/src/include/ycp/Bytecode.h
@@ -38,6 +38,12 @@ class Y2Namespace;
 
 #include <fstream>
 
+// major and minor are macros in <sys/sysmacros.h> but they are also
+// included by <sys/types.h> which is indirectly included by <string>,
+// so they're hard not to include. Let's undef them.
+#undef major
+#undef minor
+
 /// An istream that remembers some data about the bytecode.
 class bytecodeistream : public std::ifstream
 {

--- a/libycp/src/include/ycp/Xmlcode.h
+++ b/libycp/src/include/ycp/Xmlcode.h
@@ -38,6 +38,12 @@ class Y2Namespace;
 
 #include <fstream>
 
+// major and minor are macros in <sys/sysmacros.h> but they are also
+// included by <sys/types.h> which is indirectly included by <string>,
+// so they're hard not to include. Let's undef them.
+#undef major
+#undef minor
+
 /// An istream that remembers some data about the xmlcode.
 class xmlcodeistream : public std::ifstream
 {

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 10 08:34:19 UTC 2017 - mvidner@suse.com
+
+- Fixed newly uncovered warnings: Wterminate, Wint-in-bool-context,
+  sys/sysmacros (bsc#982942, bsc#434048).
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Jan  4 09:16:02 UTC 2017 - jreidinger@suse.com
 
 - Dropped the YCP debugger in yast2-core-debugger not to confuse

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        3.2.2
+Version:        4.0.0
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
This intends to make these Jenkins jobs green again:

https://ci.opensuse.org/view/Yast/job/yast-core-werror-master/
https://ci.opensuse.org/view/Yast/job/yast-core-werror-clang-master/

Note that one of the commits fixes a real bug in the code (`&&` instead of `&`), which fortunately did not have any effect.

Related:
- https://bugzilla.suse.com/show_bug.cgi?id=982942 (previous round of warning cleanup)
- https://bugzilla.suse.com/show_bug.cgi?id=434048 ("Check return codes everywhere")