### PR TITLE
Use an exclusive lock when rotating the y2log files to avoid race conditions

### DIFF
--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct  3 09:59:03 UTC 2018 - lslezak@suse.cz
+
+- Use an exclusive lock when rotating the YaST logs to avoid race
+  conditions when several YaST processes run in paralell
+  (related to bsc#1094875)
+- 4.1.0
+
+-------------------------------------------------------------------
 Fri Sep 28 16:47:42 CEST 2018 - schubi@suse.de
 
 - Reduced risk of race condition between getenv and setenv while

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.0.4
+Version:        4.1.0
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
- This avoids errors like `gzip: /var/log/YaST2/y2log-1: No such file or directory` when running parallel tests in yast2-storage-ng (see an [example Travis log](https://travis-ci.org/yast/yast-storage-ng/jobs/436182374#L752))
- The problem was that rotating y2logs was done by several processes in parallel and there was a collision.
- This is related to [bsc#1094875](https://bugzilla.suse.com/show_bug.cgi?id=1094875).
- I have tested the change with yast2-storage-ng
  - The race condition errors produced by gzip are gone
  - There was no visible delay caused by locking.

## Time Impact

It's difficult to do some precise measurement as even repeating the same yast2-storage-ng tests takes a slightly different time, probably because of different scheduling by kernel and CPU.

Some runs were faster without locking, some were faster with locking. But in general it seems to be in the same range so the effect should be hardly visible for the end users.

BTW the yast2-storage-ng testsuite is really extensive, one complete run creates `y2log` file plus all gzip archives from `y2log-1.gz` to `y2log-9.gz` (possibly even more, the limit is 10 files). During normal  usage YaST logs much less.