### PR TITLE
Fixed Clang warnings (unused variables)

### DIFF
--- a/base/tools/ycpc/ycpc.cc
+++ b/base/tools/ycpc/ycpc.cc
@@ -253,7 +253,6 @@ class FileDep {
 	std::string m_name;
 	std::string m_path;
 	bool m_is_module;	///< module or include
-	bool m_have_source;
 	time_t m_srctime;
 	time_t m_bintime;
     public:
@@ -273,7 +272,6 @@ FileDep::FileDep (const std::string & name, const std::string & path, bool is_mo
     : m_name (name)
     , m_path (path)
     , m_is_module (is_module)
-    , m_have_source (have_source)
     , m_srctime (srctime)
     , m_bintime (bintime)
 {

--- a/liby2/src/Y2Namespace.cc
+++ b/liby2/src/Y2Namespace.cc
@@ -93,7 +93,6 @@ Y2Namespace::symbolsToString () const
 {
     string s;
 
-    symbols_t::const_iterator it;
     for (unsigned int p = 0; p < m_symbolcount; p++)
     {
 	if ( m_symbols[p] )

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Nov  2 13:16:03 UTC 2018 - lslezak@suse.cz
+
+- Fixed Clang warnings (unused variables)
+
+-------------------------------------------------------------------
 Tue Oct 16 16:46:48 CEST 2018 - schubi@suse.de
 
 - Added license file to spec.


### PR DESCRIPTION
Make the https://ci.opensuse.org/view/Yast/job/yast-core-werror-clang-master/ Jenkins job happy again.