### PR TITLE
boost::logic::tribool requires explicit cast

### DIFF
--- a/libycp/src/include/ycp/YCPBoolean.h
+++ b/libycp/src/include/ycp/YCPBoolean.h
@@ -22,6 +22,7 @@
 #define YCPBoolean_h
 
 
+#include <boost/logic/tribool.hpp>
 #include "YCPValue.h"
 
 
@@ -98,6 +99,7 @@ class YCPBoolean : public YCPValue
     static YCPBoolean* falseboolean;
     
 public:
+    YCPBoolean(const boost::logic::tribool &tb) : YCPBoolean((bool)tb) {}
     YCPBoolean(bool v);
     YCPBoolean(const char *r) : YCPValue(new YCPBooleanRep(r)) {}
     YCPBoolean(bytecodeistream & str);


### PR DESCRIPTION
Since Boost 1.69.0, tribool -> bool cast is explicit.
To minimize changes in Yast2 codebase, re-add this
cast explicitly to YCPBoolean

This should fix https://bugzilla.suse.com/show_bug.cgi?id=1128364
