### PR TITLE
Fixes for gensalt handling with libxcrypt.

### DIFF
--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 19:28:00 UTC 2019 - besser82@fedoraproject.org
+
+- Fixes for gensalt handling with libxcrypt
+- 4.1.1
+
+-------------------------------------------------------------------
 Fri Nov  2 13:16:03 UTC 2018 - lslezak@suse.cz
 
 - Fixed Clang warnings (unused variables)

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
The `libxcrypt` library in version >= 4 offers support for safely generating entropy itself.  Besides that, the `<crypt.h>` header of the library already defines `CRYPT_GENSALT_OUTPUT_SIZE`.