### PR TITLE
Save memory by SCR.UnmountAgent telling agents  to terminate (bsc#1172139)

### DIFF
--- a/liby2/src/Y2CCProgram.cc
+++ b/liby2/src/Y2CCProgram.cc
@@ -94,6 +94,13 @@ Y2CCProgram::createInLevel (const char *name, int level, int current_level) cons
 	if (S_ISREG (buf.st_mode) && ((buf.st_mode & S_IXOTH) == S_IXOTH)) {
 	    if (!root.empty ())
 		file = file.substr (root.length ());
+            // NOTE(ownership/memory management)
+            //
+            // Y2ComponentCreator says that we should own the components
+            // that we create. Notably Y2CCAgentComp does
+            // but this class doesn't, leaking memory.
+            // For a quick win, SCRSubAgent deletes its Y2ProgramComponent.
+            // If this class ever owns the comp, revert SCRSubAgent.
 	    return new Y2ProgramComponent (root, file.c_str (), name,
 					   creates_non_y2, level);
 	}

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 19 07:53:36 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Save memory by SCR.UnmountAgent telling other-process agents
+  to terminate (bsc#1172139)
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 11:15:20 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fixed building with new bison 3.6 (bsc#1171505)

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Url:            https://github.com/yast/yast-core
 

--- a/scr/src/SCRSubAgent.cc
+++ b/scr/src/SCRSubAgent.cc
@@ -16,6 +16,7 @@
 
 #include <ycp/y2log.h>
 #include <y2/Y2ComponentBroker.h>
+#include <y2/Y2ProgramComponent.h>
 #include "SCRSubAgent.h"
 
 int
@@ -112,5 +113,17 @@ SCRSubAgent::mount (SCRAgent *parent)
 void
 SCRSubAgent::unmount ()
 {
-	my_comp = 0;
+    // In general, a Y2Component is owned by its Y2ComponentCreator.
+    // In practice, only some subclasses of Y2ComponentCreator
+    // delete the components they own; the others leak.
+    // Also it prevents UnmountAgent from working.
+    // Here we cheat and steal Y2ProgramComponent from Y2CCProgram,
+    // which is fine since that class does not delete the component it creates.
+    auto prog_comp = dynamic_cast<Y2ProgramComponent *>(my_comp);
+    if (prog_comp) {
+        prog_comp->result(YCPNull());
+        delete prog_comp;
+    }
+
+    my_comp = 0;
 }

--- a/scr/src/SCRSubAgent.h
+++ b/scr/src/SCRSubAgent.h
@@ -71,6 +71,13 @@ private:
 
     /**
      * The component. 0 means not created (mounted).
+     *
+     * FIXME: all components are supposed to be owned
+     * by their respective Y2ComponentCreator, but in practice
+     * many creators don't care,
+     * so this class takes a vigilante approach to delete my_comp
+     * if the component is_a Y2ProgramComponent whose Y2CCProgram
+     * is known not to care.
      */
     Y2Component *my_comp;
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1172139

[Back in 2013](https://github.com/yast/yast-core/pull/15) when we switched to Ruby, we fixed some pointer-ownership bugs at the cost of leaking some memory. The leaks were mostly academic because they occur shortly before the whole process ends anyway.

Except the leak of  *Y2ProgramComponent*, used to run agents written mostly in Perl. Special casing to not leak it means getting rid of a 31 MiB ag_udev_persistent process in the inst-sys, see also https://github.com/yast/yast-network/pull/1080.