### PR TITLE
Avoid 'Construct not supported' on UnmountAgent (bsc#1176594)

### DIFF
--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 18 15:41:56 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Avoid 'Construct not supported' on UnmountAgent (bsc#1176594)
+- 4.3.2
+
+-------------------------------------------------------------------
 Fri Jun 19 07:53:36 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Save memory by SCR.UnmountAgent telling other-process agents

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Url:            https://github.com/yast/yast-core
 

--- a/scr/src/SCRSubAgent.cc
+++ b/scr/src/SCRSubAgent.cc
@@ -121,7 +121,7 @@ SCRSubAgent::unmount ()
     // which is fine since that class does not delete the component it creates.
     auto prog_comp = dynamic_cast<Y2ProgramComponent *>(my_comp);
     if (prog_comp) {
-        prog_comp->result(YCPNull());
+        prog_comp->result(YCPVoid());
         delete prog_comp;
     }
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1176594 (P1)
- https://trello.com/c/n8N5NvO1

This was an oversight of mine in #147 - that PR did the job but introduced the log error that is now getting fixed.

To reproduce the bug and test the fix, on Tumbleweed: (`<3>` is the Error level)

```
# ruby -ryast -e 'p Yast::SCR.Read(Yast.path(".udev_persistent"))'; grep '<3>' /var/log/YaST2/y2log
```