### PR TITLE
Fix CLang build by avoiding -flto=auto.

### DIFF
--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -99,6 +99,11 @@ export CC=clang CXX=clang++
 # warning/error: argument unused during compilation
 CFLAGS="${CFLAGS/-grecord-gcc-switches/}"
 CXXFLAGS="${CXXFLAGS/-grecord-gcc-switches/}"
+
+# "unsupported argument 'auto' to option 'flto='"
+# This time it comes from RPM macro expansion
+# so let's override /usr/lib/rpm/suse/macros
+%define _lto_cflags %{nil}
 %endif
 
 %yast_build


### PR DESCRIPTION
CLang builds have been failing, ([ci.o.o example](https://ci.opensuse.org/job/yast-core-clang-master/39/console)) with 

>  configure: error: C compiler cannot create executables

I've built it locally (`rake 'osc:build[--with werror --with clang]'`) to reveal:

```
configure:3716: checking whether the C compiler works
configure:3738: clang -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection
 -Werror=return-type -flto=auto -Werror  -flto=auto conftest.c  >&5
clang-10.0: error: unsupported argument 'auto' to option 'flto='
```

It seems to be the fault of an office mate :) https://gcc.gnu.org/legacy-ml/gcc-patches/2019-07/msg01488.html
