### PR TITLE
Add missing library dependencies (bsc#1197120)

### DIFF
--- a/libscr/src/Makefile.am
+++ b/libscr/src/Makefile.am
@@ -18,3 +18,7 @@ AM_CPPFLAGS =						\
 	${Y2UTIL_CFLAGS}
 
 libscr_la_LDFLAGS = -version-info 3:0
+libscr_la_LIBADD = \
+	$(top_srcdir)/libycp/src/libycp.la \
+	$(top_srcdir)/libycp/src/libycpvalues.la \
+	${Y2UTIL_LIBS}

--- a/libycp/src/Makefile.am
+++ b/libycp/src/Makefile.am
@@ -68,8 +68,7 @@ libycp_la_LDFLAGS = -version-info 5:0:0
 libycp_la_LIBADD = \
 	libycpvalues.la \
 	$(top_srcdir)/liby2/src/liby2.la \
-	${Y2UTIL_LIBS} \
-	${CRYPTO_LIBS}
+	${Y2UTIL_LIBS}
 
 CLEANFILES = parser.output parser.cc scanner.cc $(BUILT_SOURCES)
 

--- a/libycp/src/Makefile.am
+++ b/libycp/src/Makefile.am
@@ -65,7 +65,11 @@ libycpvalues_la_LDFLAGS = -version-info 6:0:0
 libycpvalues_la_LIBADD = ${Y2UTIL_LIBS} 
 
 libycp_la_LDFLAGS = -version-info 5:0:0
-libycp_la_LIBADD = ${Y2UTIL_LIBS} ${CRYPTO_LIBS} libycpvalues.la
+libycp_la_LIBADD = \
+	libycpvalues.la \
+	$(top_srcdir)/liby2/src/liby2.la \
+	${Y2UTIL_LIBS} \
+	${CRYPTO_LIBS}
 
 CLEANFILES = parser.output parser.cc scanner.cc $(BUILT_SOURCES)
 

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May  4 08:42:31 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Add missing library dependencies (bsc#1197120)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
## References

- https://bugzilla.suse.com/show_bug.cgi?id=1197120
- https://trello.com/c/PMo8iWEx/2946-3-tw-p3-1197120-what-to-do-about-libjemalloc
- related, Y2DISABLELANGUAGEPLUGINS=1 for ag_udev persistent: https://github.com/yast/yast-network/pull/1290

## Problem

```console
tail -f ~/.y2log & # or
tail -f /var/log/YaST2/y2log &
echo 'Dir (.)' | Y2DISABLELANGUAGEPLUGINS=1 /usr/lib/YaST2/servers_non_y2/ag_udev_persistent
```

would result in
> [liby2] Y2PluginComponent.cc(loadPlugin):234 error loading plugin /usr/lib64/YaST2/plugin/libpy2scr.so.2: /usr/lib64/YaST2/plugin/libpy2scr.so.2: undefined symbol: _ZTI18Y2ComponentCreator

### Explanation

yast-core has for historical reasons many small shared libraries which depend
on one another. They are almost always all loaded together.
So when a library libfoo uses a symbol from another libbar but does not
declare it with a -lbar linker option, it is not a problem because some other
library from the group will -lbar.

Some libraries are plugins, optionally loaded with dlopen.

In https://bugzilla.suse.com/show_bug.cgi?id=1197120
(root cause: unrelated; symptom: error message about jemalloc)
it turned out that stdio-communicating agents
`/usr/lib/YaST2/servers_non_y2/ag_*`, written mostly in Perl, are loading:

1. the Perl-YCP binding (to be able to parse YCP traffic)
2. all the language bindings: Perl, Ruby, Python

(2) is unnecessary and, by dlopen-ing Ruby, produces the jemalloc error.

(2) can be disabled by putting Y2DISABLELANGUAGEPLUGINS=1 into the
environment. When doing that, the missing dependencies in the remaining
libraries are uncovered.

## Solution

Add the missing dependencies


## Testing

Tested manually, by:

applying this PR on the SP2 branch, compiling and installing on my workstation, running the **Problem** commands

## Screenshots

N/A, CLI only
