### PR TITLE
.target.tmpdir -  honor the target root (bsc#1199840)

### DIFF
--- a/agent-system/src/SystemAgent.h
+++ b/agent-system/src/SystemAgent.h
@@ -53,8 +53,9 @@ public:
 
 private:
 
-    string tempdir;
-
+    // temporary directory, an absolute path with the current root (chroot) prefix!
+    string _tempdir;
+    string tempdir();
 };
 
 

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Jul 25 14:19:37 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed ".target.tmpdir":
+  - Create the temporary directory in the target root (bsc#1199840)
+  - The temporary directory is now created only when needed
+  - Check if the target /tmp directory exists
+- 4.5.3
+
+-------------------------------------------------------------------
 Mon Jul  4 13:46:48 UTC 2022 - Martin Liška <mliska@suse.cz>
 
 - Fix building with GCC 13 and GCC 12.x (gh#yast/yast-core#156)

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
## Problem

The `.target.tmpdir` agent creates the temporary directory in the current system root.

That makes troubles when the SCR is chrooted. In that case the other agents (`.target.string` or `target.bash`) use the chroot and the temporary directory is not reachable from there as it is outside the chroot.

This causes problems when running YaST in a container.

## Solution

The solution required to move the code from the constructor and create the temporary directory at the first access. The reason is that the `root()` call returns the `/` path in the constructor, the correct target root is set later.

## Notes

- Now the code checks whether the `/tmp` directory exists in the target root, this might be useful in testing when you use an empty chroot.
- The lazy creating has a side effect that the temporary directory is not created when not needed.

## Testing

Tested manually with this small testing Ruby script:

```ruby
#! /usr/bin/env ruby

require "tmpdir"
require "yast"

def print_scr_tmpdir
  puts "SCR root: #{Yast::WFM.scr_root}"
  scr_tmpdir = Yast::SCR.Read(Yast::path(".target.tmpdir"))
  puts ".target.tmpdir: #{scr_tmpdir}"
  dir = File.join(Yast::WFM.scr_root, scr_tmpdir)
  puts "#{dir} exists: #{File.exist?(dir)}"
  puts ".target.bash_output(\"ls -l #{scr_tmpdir}\"): #{Yast::SCR.Execute(Yast::path(".target.bash_output"), "ls -l #{scr_tmpdir}").inspect}"
  puts
end

# print ".target.tmpdir" for standard root (/)
print_scr_tmpdir

# print ".target.tmpdir" for a chroot
handle = Yast::WFM.SCROpen("chroot=#{ENV["YAST_SCR_TARGET"]}:scr", false)
Yast::WFM.SCRSetDefault(handle)

print_scr_tmpdir
```

This code checks the behavior in both cases, running in standard root and running in a chroot.

### Results

With the original code it failed when running in a container with this error:

```
# ./tmpdir_test.rb 
SCR root: /
.target.tmpdir: /tmp/YaST2-09483-2vNEUh
/tmp/YaST2-09483-2vNEUh exists: true
.target.bash_output("ls -l /tmp/YaST2-09483-2vNEUh"): {"exit"=>0, "stderr"=>"", "stdout"=>"total 0\n-rw-r--r-- 1 root root 0 Jul 22 11:35 stderr\n-rw-r--r-- 1 root root 0 Jul 22 11:35 stdout\n"}

SCR root: /mnt
.target.tmpdir: /tmp/YaST2-09483-cyjDYe
/mnt/tmp/YaST2-09483-cyjDYe exists: false
.target.bash_output("ls -l /tmp/YaST2-09483-cyjDYe"): {"exit"=>2, "stderr"=>"ls: cannot access '/tmp/YaST2-09483-cyjDYe': No such file or directory\n", "stdout"=>""}
```

After fixing `.target.tmpdir` it works as expected:

```
./tmpdir_test.rb 
SCR root: /
.target.tmpdir: /tmp/YaST2-10185-UnHBqm
/tmp/YaST2-10185-UnHBqm exists: true
.target.bash_output("ls -l /tmp/YaST2-10185-UnHBqm"): {"exit"=>0, "stderr"=>"", "stdout"=>"total 0\n-rw-r--r-- 1 root root 0 Jul 22 11:35 stderr\n-rw-r--r-- 1 root root 0 Jul 22 11:35 stdout\n"}

SCR root: /mnt
.target.tmpdir: /tmp/YaST2-10185-ERPiTk
/mnt/tmp/YaST2-10185-ERPiTk exists: true
.target.bash_output("ls -l /tmp/YaST2-10185-ERPiTk"): {"exit"=>0, "stderr"=>"", "stdout"=>"total 0\n-rw-r--r-- 1 root root 0 Jul 22 13:35 stderr\n-rw-r--r-- 1 root root 0 Jul 22 13:35 stdout\n"}
```

## GitHub Action

The GitHub Action is failing because of missing `glibc-locale` package in the image. Fixed with https://github.com/yast/ci-ruby-container/pull/20.