### PR TITLE
Fix doc link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,3 @@ tmp.*
 */testsuite/site.exp
 *.in.test
 /config.h.in~
-/.yardoc
-/doc

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,7 +13,7 @@ heavily used during installation.
 The agents for the target system are managed by a SCR instance. Each agent is
 attached to its unique YaST path. Read more about SCR, YaST paths and their
 relationship with the agents in the "YaST architecture" document at the
-[YaST documentation page](http://yast.github.io/documentation.html).
+[YaST documentation page](http://yast.github.io/documentation).
 
 Each agent is defined by its scrconf file which can contain either a base 
 with some parameters either a path to a binary if the agent


### PR DESCRIPTION
## Problem

As reported in https://github.com/yast/yast-kdump/issues/125 , one of the links in doc/README led to a 404.

- https://trello.com/c/j7DQjsi6/2836-1-fix-documentation-links-ptesarik-contrib

## Solution

Fix the link

## Testing

Click the link

## Screenshots

No