### PR TITLE
Don't close file descriptors in .target.bash calls (bsc#1218064)

### DIFF
--- a/agent-system/src/ShellCommand.cc
+++ b/agent-system/src/ShellCommand.cc
@@ -145,9 +145,10 @@ shellcommand ( const string &target_root, const string &command, const string &t
 
 	    // #223602
 	    // close all file descriptors above stderr
-	    for ( int i = getdtablesize() - 1; i > 2; --i ) {
-		close( i );
-	    }
+            //
+            // But Ruby uses some for thread communications,
+            // bsc#1218064, so don't.
+            // Systemd daemon handling has meanwhile solved the original bug.
 
             // we want to work on different target root
             if (target_root != "/")

--- a/package/yast2-core.changes
+++ b/package/yast2-core.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 10 16:22:03 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Don't close file descriptors in .target.bash calls (bsc#1218064)
+  avoiding "[ASYNC BUG] rb_thread_wakeup_timer_thread: write(3) EBADF"
+  with Ruby 3.3
+- 5.0.2
+
+-------------------------------------------------------------------
 Tue Nov 28 13:24:23 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Do not test YCP on non-UTF-8 strings (bsc#1217523)

--- a/package/yast2-core.spec
+++ b/package/yast2-core.spec
@@ -26,7 +26,7 @@
 %bcond_with werror
 
 Name:           yast2-core
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Url:            https://github.com/yast/yast-core
 


### PR DESCRIPTION
## Problem

With Ruby 3.3, yast2.rpm build fails with "[ASYNC BUG] rb_thread_wakeup_timer_thread: write(3) EBADF"
See: https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:I/yast2/standard/x86_64

It's because in `.target.bash` implementation we close file descriptors numbered 3 and above, not to leak them to daemons we start ([bsc#223602](https://bugzilla.suse.com/show_bug.cgi?id=223602))

- https://bugzilla.suse.com/show_bug.cgi?id=1216689 (was pointing to the wrong bug before)
- old bug: [bsc#223602](https://bugzilla.suse.com/show_bug.cgi?id=223602)
- https://trello.com/c/E0NU47vG/3514-adapt-to-ruby-33

## Solution

Don't close those FDs.

The original problem is meanwhile likely solved by starting daemons via systemd, which 

A better solution would be to call Ruby's `rb_reserved_fd_p(fd)` API to avoid precisely its internal FDs, but yast-core technically doesn't depend on Ruby.

## Testing

Tested building yast-core and yast-yast2 in Staging:I, no error

## Screenshots

N/A
